### PR TITLE
GUAC-55: Set reveal view background color to clear

### DIFF
--- a/SWRevealViewController/SWRevealViewController.m
+++ b/SWRevealViewController/SWRevealViewController.m
@@ -760,9 +760,6 @@ const int FrontViewPositionNone = 0xff;
     // set our contentView to the controllers view
     self.view = _contentView;
     
-    // Apple also tells us to do this:
-    _contentView.backgroundColor = [UIColor blackColor];
-    
     // we set the current frontViewPosition to none before seting the
     // desired initial position, this will force proper controller reload
     FrontViewPosition initialPosition = _frontViewPosition;


### PR DESCRIPTION
Otherwise if I try to set the color of the view from outside of the class (say, the app delegate) things get real funky. This way, I'd rather just set the background color of the underlying view controller or window and call it good.